### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Note
-For **latest** version of this project please take a look [here](https://github.com/GoogleCloudPlatform/ai-platform-samples/tree/master/notebooks/notebooks-ci-showcase)
+For **latest** version of this project please take a look [here](https://github.com/GoogleCloudPlatform/ai-platform-samples/tree/master/notebooks/tools/notebooks-ci-showcase)
 
 # Fully Configured Example of CI/CD for Notebooks on Top of Google Cloud Platform
 


### PR DESCRIPTION
Having arrived here from the link given at the Cloud Next '19 talk, I found that the link to the latest version was broken.
The new link will allow any future users to easily reach the latest version and may indirectly fix #3 